### PR TITLE
feat: SAM으로 FastAPI 서버리스 마이그레이션 및 트러블슈팅

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,4 @@
 .venv/
 venv/
 __pycache__/
-.cursor/
-.cursorignore
-images/ 
+.aws-sam/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 .venv/
 venv/
 __pycache__/
-.cursor/
-.cursorignore
 images/ 
+.aws-sam/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,14 @@
-# 1. 베이스 이미지 설정 (소스에 명시된 Python 3.10+ 반영)
-FROM python:3.10-slim
+FROM public.ecr.aws/lambda/python:3.10
 
-# 2. 작업 디렉토리 설정
-WORKDIR /app
+# 람다 작업 디렉토리 명시
+WORKDIR ${LAMBDA_TASK_ROOT}
 
-# 3. 의존성 파일 복사 및 설치
+# 1. 라이브러리 설치 (캐시 활용)
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# 4. 소스 코드 및 이미지 자산 복사
+# 2. 현재 폴더의 모든 내용 복사 (main.py가 이 안에 있어야 함)
 COPY . .
 
-# 5. 환경 변수 설정 (AWS 인증 정보 등은 런타임에 주입하는 것을 권장)
-# ENV AWS_ACCESS_KEY_ID=your_key
-# ENV AWS_SECRET_ACCESS_KEY=your_secret
-
-# 6. FastAPI 서버 실행 (Uvicorn 사용)
-EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+# 3. 핸들러 실행 (main.py 내의 handler 객체 호출)
+CMD [ "main.handler" ]

--- a/database.py
+++ b/database.py
@@ -1,39 +1,3 @@
-# region agent log helper
-import json
-import time
-import hashlib
-
-_AGENT_LOG_PATH = r"c:\Users\USER\MalangMaker\.cursor\debug.log"
-
-
-def _agent_uid8(value) -> str:
-    try:
-        s = str(value).encode("utf-8", errors="ignore")
-        return hashlib.sha256(s).hexdigest()[:8]
-    except Exception:
-        return "uid_err"
-
-
-def _agent_log(
-    *, runId: str, hypothesisId: str, location: str, message: str, data: dict
-):
-    try:
-        payload = {
-            "sessionId": "debug-session",
-            "runId": runId,
-            "hypothesisId": hypothesisId,
-            "location": location,
-            "message": message,
-            "data": data,
-            "timestamp": int(time.time() * 1000),
-        }
-        with open(_AGENT_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(payload, ensure_ascii=False) + "\n")
-    except Exception:
-        pass
-
-
-# endregion
 # ==========================================
 # ⚙️ 1. 초기 설정 및 환경 변수 (CONFIG)
 # ==========================================
@@ -48,13 +12,24 @@ from descriptions import get_malang_data, USER_TITLES, MALANG_CONFIG
 
 load_dotenv()
 
-# DynamoDB 접속 설정
-dynamodb = boto3.resource(
-    "dynamodb",
-    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
-    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
-    region_name=os.getenv("AWS_REGION"),
-)
+# 환경 변수에 따라 다르게 동작하도록 설정
+if os.getenv("AWS_LAMBDA_FUNCTION_NAME"):
+    # Lambda 환경: IAM Role을 자동으로 사용하므로 별도 Key가 필요 없음
+    dynamodb = boto3.resource(
+        "dynamodb", region_name=os.getenv("AWS_REGION", "ap-northeast-2")
+    )
+else:
+    # 로컬 환경: 기존 방식대로 .env 사용 [1]
+    from dotenv import load_dotenv
+
+    load_dotenv()
+    dynamodb = boto3.resource(
+        "dynamodb",
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+        region_name=os.getenv("AWS_REGION"),
+    )
+
 table = dynamodb.Table("MalangUsers")
 
 
@@ -195,20 +170,6 @@ def reset_malang_data(user_id, room_id):
     try:
         new_type = random.choice(["typeA", "typeB", "typeC"])
 
-        # region agent log (H6)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H6",
-            location="database.py:reset_malang_data:entry",
-            message="reset entry",
-            data={
-                "uid8": _agent_uid8(user_id),
-                "room8": _agent_uid8(room_id),
-                "new_type": new_type,
-            },
-        )
-        # endregion
-
         initial_title, _ = get_malang_data(new_type, 1)
 
         malang = get_or_create_malang(user_id)
@@ -240,35 +201,8 @@ def reset_malang_data(user_id, room_id):
         )
 
         img_url = get_malang_image(1, new_type)
-        # region agent log (H6)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H6",
-            location="database.py:reset_malang_data:success",
-            message="reset success",
-            data={
-                "uid8": _agent_uid8(user_id),
-                "new_type": new_type,
-                "msg_len": len(msg),
-                "img_url_head": (img_url or "")[:60],
-            },
-        )
-        # endregion
         return msg, img_url
     except Exception as e:
-        # region agent log (H6)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H6",
-            location="database.py:reset_malang_data:exception",
-            message="reset exception",
-            data={
-                "uid8": _agent_uid8(user_id),
-                "err_type": type(e).__name__,
-                "err_msg": str(e)[:200],
-            },
-        )
-        # endregion
         print(f"Error: {e}")  # 로그 확인용
         return f"분양 과정에서 오류가 발생했어요: {e}", ""
 
@@ -283,44 +217,11 @@ def feed_malang(user_id, room_id):
         malang = get_or_create_malang(user_id)
         rand_val = random.random()  # 0.0 ~ 1.0 사이의 랜덤값
 
-        # region agent log (H2)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H2",
-            location="database.py:feed_malang:entry",
-            message="feed_malang entry",
-            data={
-                "uid8": _agent_uid8(user_id),
-                "room8": _agent_uid8(room_id),
-                "malang_keys": sorted(list(malang.keys()))[:25],
-                "level_raw": str(malang.get("level")),
-                "type_raw": str(malang.get("type")),
-                "health_raw": str(malang.get("health")),
-                "exp_raw": str(malang.get("exp")),
-            },
-        )
-        # endregion
-
         new_health = int(malang["health"])
         new_level = int(malang["level"])
         new_exp = int(malang["exp"])
         malang_type = malang.get("type", "typeA")
         malang_display_name = malang.get("malang_name", "말랑이")
-
-        # region agent log (H1)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H1",
-            location="database.py:feed_malang:before_config",
-            message="type/config check",
-            data={
-                "uid8": _agent_uid8(user_id),
-                "malang_type": str(malang_type),
-                "type_in_config": bool(malang_type in MALANG_CONFIG),
-                "rand_val": rand_val,
-            },
-        )
-        # endregion
 
         malang_name = MALANG_CONFIG.get(malang_type, MALANG_CONFIG[malang_type])[
             "status"
@@ -350,15 +251,6 @@ def feed_malang(user_id, room_id):
         # 2. 확률별 로직 처리
         # [0.5% 확률] 전설의 만두 (희귀!!)
         if rand_val < 0.005:
-            # region agent log (H1)
-            _agent_log(
-                runId="run1",
-                hypothesisId="H1",
-                location="database.py:feed_malang:branch",
-                message="branch selected: legend",
-                data={"uid8": _agent_uid8(user_id), "rand_val": rand_val},
-            )
-            # endregion
             new_level += 1
             new_health = 100
             new_exp = 0
@@ -372,15 +264,6 @@ def feed_malang(user_id, room_id):
 
         # [15% 확률] 상한 밥 (실패!!)
         elif rand_val < 0.155:
-            # region agent log (H1)
-            _agent_log(
-                runId="run1",
-                hypothesisId="H1",
-                location="database.py:feed_malang:branch",
-                message="branch selected: bad",
-                data={"uid8": _agent_uid8(user_id), "rand_val": rand_val},
-            )
-            # endregion
             damage = random.randint(15, 30)
             new_health -= damage
             header = "💀⛈️ [ F A I L ] ⛈️💀"
@@ -393,15 +276,6 @@ def feed_malang(user_id, room_id):
 
         # [그 외] 무난한 밥 (성공!!)
         else:
-            # region agent log (H1)
-            _agent_log(
-                runId="run1",
-                hypothesisId="H1",
-                location="database.py:feed_malang:branch",
-                message="branch selected: normal",
-                data={"uid8": _agent_uid8(user_id), "rand_val": rand_val},
-            )
-            # endregion
             normal_foods = [
                 {"name": "고소한 콩떡", "heal": 10, "exp": 15},
                 {"name": "달콤한 꿀단지", "heal": 20, "exp": 10},
@@ -496,19 +370,6 @@ def feed_malang(user_id, room_id):
 
         return final_msg, image_url
     except Exception as e:
-        # region agent log (H3)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H3",
-            location="database.py:feed_malang:exception",
-            message="exception in feed_malang",
-            data={
-                "uid8": _agent_uid8(user_id),
-                "err_type": type(e).__name__,
-                "err_msg": str(e)[:200],
-            },
-        )
-        # endregion
         raise
 
 

--- a/main.py
+++ b/main.py
@@ -2,37 +2,7 @@ from fastapi import FastAPI, Request
 import json
 import time
 import hashlib
-
-# region agent log helper
-_AGENT_LOG_PATH = r"c:\Users\USER\MalangMaker\.cursor\debug.log"
-
-
-def _agent_uid8(value) -> str:
-    try:
-        s = str(value).encode("utf-8", errors="ignore")
-        return hashlib.sha256(s).hexdigest()[:8]
-    except Exception:
-        return "uid_err"
-
-
-def _agent_log(
-    *, runId: str, hypothesisId: str, location: str, message: str, data: dict
-):
-    try:
-        payload = {
-            "sessionId": "debug-session",
-            "runId": runId,
-            "hypothesisId": hypothesisId,
-            "location": location,
-            "message": message,
-            "data": data,
-            "timestamp": int(time.time() * 1000),
-        }
-        with open(_AGENT_LOG_PATH, "a", encoding="utf-8") as f:
-            f.write(json.dumps(payload, ensure_ascii=False) + "\n")
-    except Exception:
-        # 로깅 실패는 서비스 동작에 영향 주지 않음
-        pass
+from mangum import Mangum
 
 
 # endregion
@@ -50,6 +20,8 @@ from database import (
 )
 
 app = FastAPI()
+
+handler = Mangum(app, lifespan="off")
 
 
 @app.post("/message")
@@ -84,38 +56,6 @@ async def kakao_skill(request: Request):
     malang = get_or_create_malang(user_id, nickname)
     current_lvl = int(malang["level"])
     origin_malang_type = malang["type"]
-
-    # region agent log (H5)
-    _agent_log(
-        runId="run1",
-        hypothesisId="H5",
-        location="main.py:kakao_skill:after_parse",
-        message="request parsed",
-        data={
-            "uid8": _agent_uid8(user_id),
-            "room8": _agent_uid8(room_id),
-            "utterance": user_input[:50],
-            "nickname_present": bool(nickname),
-        },
-    )
-    # endregion
-
-    # region agent log (H2)
-    _agent_log(
-        runId="run1",
-        hypothesisId="H2",
-        location="main.py:kakao_skill:after_get_or_create",
-        message="malang loaded",
-        data={
-            "uid8": _agent_uid8(user_id),
-            "malang_keys": sorted(list(malang.keys()))[:25],
-            "level_raw": str(malang.get("level")),
-            "type_raw": str(malang.get("type")),
-            "health_raw": str(malang.get("health")),
-            "exp_raw": str(malang.get("exp")),
-        },
-    )
-    # endregion
 
     quick_replies = []
     # 🎮 명령어 분기 처리
@@ -158,46 +98,9 @@ async def kakao_skill(request: Request):
 
     # 새로 분양 (가이드에 /리셋도 표기되어 있어 동일 처리)
     if "/분양" in user_input or "/리셋" in user_input:
-        # region agent log (H6)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H6",
-            location="main.py:kakao_skill:branch_reset",
-            message="branch selected: reset/adopt",
-            data={"uid8": _agent_uid8(user_id), "room8": _agent_uid8(room_id)},
-        )
-        # endregion
         try:
             msg, img_url = reset_malang_data(user_id, room_id)
-            # region agent log (H6)
-            _agent_log(
-                runId="run1",
-                hypothesisId="H6",
-                location="main.py:kakao_skill:after_reset",
-                message="reset returned",
-                data={
-                    "uid8": _agent_uid8(user_id),
-                    "msg_len": len(msg or ""),
-                    "msg_head": (msg or "")[:40],
-                    "img_url_head": (img_url or "")[:60],
-                    "img_url_empty": not bool(img_url),
-                },
-            )
-            # endregion
         except Exception as e:
-            # region agent log (H6)
-            _agent_log(
-                runId="run1",
-                hypothesisId="H6",
-                location="main.py:kakao_skill:reset_exception",
-                message="exception in reset_malang_data call",
-                data={
-                    "uid8": _agent_uid8(user_id),
-                    "err_type": type(e).__name__,
-                    "err_msg": str(e)[:200],
-                },
-            )
-            # endregion
             raise
 
     # 만렙 제한 로직 (밥, 쓰다듬기, 기술 방어)
@@ -234,30 +137,7 @@ async def kakao_skill(request: Request):
     # ==========================================
     # 1. 밥 주기
     elif "/밥" in user_input:
-        # region agent log (H5)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H5",
-            location="main.py:kakao_skill:branch_feed",
-            message="branch selected: feed",
-            data={"uid8": _agent_uid8(user_id), "room8": _agent_uid8(room_id)},
-        )
-        # endregion
         msg, img_url = feed_malang(user_id, room_id)
-        # region agent log (H4)
-        _agent_log(
-            runId="run1",
-            hypothesisId="H4",
-            location="main.py:kakao_skill:after_feed",
-            message="feed returned",
-            data={
-                "uid8": _agent_uid8(user_id),
-                "msg_len": len(msg or ""),
-                "img_url_head": (img_url or "")[:60],
-                "img_url_has_dead": bool(img_url and "dead" in img_url),
-            },
-        )
-        # endregion
         if img_url and "dead" in img_url:
             buttons = [
                 {
@@ -398,24 +278,5 @@ async def kakao_skill(request: Request):
             ]
         },
     }
-    # region agent log (H7)
-    _agent_log(
-        runId="run1",
-        hypothesisId="H7",
-        location="main.py:kakao_skill:before_return",
-        message="response assembled",
-        data={
-            "uid8": _agent_uid8(user_id),
-            "utterance": user_input[:20],
-            "msg_len": len(msg or ""),
-            "img_url_head": (img_url or "")[:60],
-            "buttons_cnt": len(buttons or []),
-            "outputs_cnt": len(res_card.get("template", {}).get("outputs", [])),
-            "has_itemCard": any(
-                isinstance(o, dict) and "itemCard" in o
-                for o in res_card.get("template", {}).get("outputs", [])
-            ),
-        },
-    )
     # endregion
     return res_card

--- a/malang-maker-migration.md
+++ b/malang-maker-migration.md
@@ -1,0 +1,50 @@
+# [Technical Review] 말랑이 메이커 #2: SAM으로 FastAPI 서버리스 마이그레이션 및 트러블슈팅
+
+### 전체 아키텍처 흐름
+* **FastAPI에 Mangum 부착**: 기존 웹 프레임워크를 Lambda가 이해할 수 있게 변환함.
+* **Docker & ECR**: 코드를 컨테이너 이미지로 빌드하여 AWS ECR에 푸시함.
+* **AWS Lambda**: 업로드된 이미지를 기반으로 서버리스 함수를 실행함.
+* **API Gateway**: Lambda를 외부(카카오톡 챗봇 등)와 연결해 주는 관문 역할을 함.
+* **IAM Role**: Lambda가 DynamoDB에 접근할 수 있도록 권한을 제한함.
+* **AWS SAM**: 인프라 생성과 배포 과정을 템플릿 하나로 자동화함.
+* **테스트**: 로컬 빌드 및 실제 환경 테스트를 진행함.
+
+---
+
+### 주요 코드 및 설정 변경 (SAM & FastAPI)
+**1. SAM 템플릿 (template.yaml)**
+* 소스 코드 직배포가 아니라 도커 이미지를 사용하므로 `PackageType: Image`로 명시함.
+
+**2. 환경별 DB 분기 (db.py)**
+* 로컬은 `.env`를 읽고, Lambda 환경은 부여된 IAM Role을 쓰도록 `os.getenv("AWS_LAMBDA_FUNCTION_NAME")` 기준으로 분기 처리함.
+
+**3. 어댑터 장착 (main.py)**
+* `handler = Mangum(app, lifespan="off")` 설정을 통해 FastAPI와 Lambda를 연결함.
+
+**4. 도커 베이스 변경 (Dockerfile)**
+* `public.ecr.aws/lambda/python:3.10`과 같은 AWS 전용 이미지로 베이스를 교체하고 `CMD ["main.handler"]`를 설정함.
+
+### 트러블슈팅
+**1. 카카오톡 NetworkAccessForbidden (응답 없음)**
+* **원인**: 일반 Python slim 이미지를 사용해 Lambda 런타임이 초기화되지 못함.
+* **해결**: 베이스 이미지를 AWS 전용 런타임 이미지(`public.ecr.aws/lambda/python:3.10`)로 변경함.
+
+**2. 카카오톡 챗봇 503 에러**
+* **원인**: 서버 내부 에러 발생 시 카카오에서 연결을 차단함.
+* **해결**: `sam logs`로 로그를 분석하고, Mangum 설정에 `lifespan="off"`를 추가하여 수정함.
+
+**3. Runtime.ImportModuleError (Unable to import module 'main')**
+* **원인**: 빌드 캐시가 꼬여서 도커 내부의 `main.py`를 찾지 못함.
+* **해결**: `.aws-sam` 폴더를 완전히 날려버리고 재빌드하여 해결함.
+
+**4. AWS_REGION 예약어 충돌**
+* **원인**: AWS 람다가 내부적으로 사용하는 예약어(`AWS_REGION`)를 환경 변수명으로 사용함.
+* **해결**: 변수 이름을 `MY_APP_REGION`과 같은 커스텀 명칭으로 변경함.
+
+**5. 이미지 파일 증발**
+* **원인**: `.dockerignore` 파일에 `img` 폴더가 포함되어 서버에 이미지가 올라가지 않음.
+* **해결**: 해당 항목을 삭제하고 재배포함.
+
+**6. 브라우저 {"detail":"Method Not Allowed"} 메시지**
+* **원인**: API는 POST 방식만 허용하는데 브라우저에서 GET 방식으로 접근함.
+* **결론**: 에러가 아니라 서버가 정상적으로 작동하여 보안 방어가 이루어지고 있다는 증거임.

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -1,0 +1,12 @@
+version = 0.1
+
+[default.deploy.parameters]
+stack_name = "malang-maker"
+resolve_s3 = true
+s3_prefix = "malang-maker"
+confirm_changeset = true
+capabilities = "CAPABILITY_IAM"
+image_repositories = ["MalangMakerFunction=212315285588.dkr.ecr.ap-northeast-2.amazonaws.com/malangmaker791a2d3b/malangmakerfunction6a0fc02crepo"]
+
+[default.global.parameters]
+region = "ap-northeast-2"

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Malang Maker FastAPI Serverless App (Docker Image)
+
+Globals:
+  Function:
+    Timeout: 30
+    MemorySize: 512
+    Environment:
+      Variables:
+        DYNAMODB_TABLE: MalangUsers
+        MY_APP_REGION: ap-northeast-2
+
+Resources:
+  MalangMakerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      # 핵심 수정: 소스 코드가 아니라 이미지를 사용한다고 명시
+      PackageType: Image
+      Architectures:
+        - x86_64
+      Policies:
+        - DynamoDBCrudPolicy:
+            TableName: MalangUsers
+      Events:
+        MalangApi:
+          Type: Api
+          Properties:
+            Path: /{proxy+}
+            Method: ANY
+    Metadata:
+      # Dockerfile 정보 연동
+      Dockerfile: Dockerfile
+      DockerContext: ./
+      DockerTag: v1
+
+Outputs:
+  MalangMakerApi:
+    Description: "API Gateway endpoint URL"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/"


### PR DESCRIPTION
### 전체 아키텍처 흐름
* **FastAPI에 Mangum 부착**: 기존 웹 프레임워크를 Lambda가 이해할 수 있게 변환함.
* **Docker & ECR**: 코드를 컨테이너 이미지로 빌드하여 AWS ECR에 푸시함.
* **AWS Lambda**: 업로드된 이미지를 기반으로 서버리스 함수를 실행함.
* **API Gateway**: Lambda를 외부(카카오톡 챗봇 등)와 연결해 주는 관문 역할을 함.
* **IAM Role**: Lambda가 DynamoDB에 접근할 수 있도록 권한을 제한함.
* **AWS SAM**: 인프라 생성과 배포 과정을 템플릿 하나로 자동화함.
* **테스트**: 로컬 빌드 및 실제 환경 테스트를 진행함.

---

### 주요 코드 및 설정 변경 (SAM & FastAPI)
**1. SAM 템플릿 (template.yaml)**
* 소스 코드 직배포가 아니라 도커 이미지를 사용하므로 `PackageType: Image`로 명시함.

**2. 환경별 DB 분기 (db.py)**
* 로컬은 `.env`를 읽고, Lambda 환경은 부여된 IAM Role을 쓰도록 `os.getenv("AWS_LAMBDA_FUNCTION_NAME")` 기준으로 분기 처리함.

**3. 어댑터 장착 (main.py)**
* `handler = Mangum(app, lifespan="off")` 설정을 통해 FastAPI와 Lambda를 연결함.

**4. 도커 베이스 변경 (Dockerfile)**
* `public.ecr.aws/lambda/python:3.10`과 같은 AWS 전용 이미지로 베이스를 교체하고 `CMD ["main.handler"]`를 설정함.

### 트러블슈팅
**1. 카카오톡 NetworkAccessForbidden (응답 없음)**
* **원인**: 일반 Python slim 이미지를 사용해 Lambda 런타임이 초기화되지 못함.
* **해결**: 베이스 이미지를 AWS 전용 런타임 이미지(`public.ecr.aws/lambda/python:3.10`)로 변경함.

**2. 카카오톡 챗봇 503 에러**
* **원인**: 서버 내부 에러 발생 시 카카오에서 연결을 차단함.
* **해결**: `sam logs`로 로그를 분석하고, Mangum 설정에 `lifespan="off"`를 추가하여 수정함.

**3. Runtime.ImportModuleError (Unable to import module 'main')**
* **원인**: 빌드 캐시가 꼬여서 도커 내부의 `main.py`를 찾지 못함.
* **해결**: `.aws-sam` 폴더를 완전히 날려버리고 재빌드하여 해결함.

**4. AWS_REGION 예약어 충돌**
* **원인**: AWS 람다가 내부적으로 사용하는 예약어(`AWS_REGION`)를 환경 변수명으로 사용함.
* **해결**: 변수 이름을 `MY_APP_REGION`과 같은 커스텀 명칭으로 변경함.

**5. 이미지 파일 증발**
* **원인**: `.dockerignore` 파일에 `img` 폴더가 포함되어 서버에 이미지가 올라가지 않음.
* **해결**: 해당 항목을 삭제하고 재배포함.

**6. 브라우저 {"detail":"Method Not Allowed"} 메시지**
* **원인**: API는 POST 방식만 허용하는데 브라우저에서 GET 방식으로 접근함.
* **결론**: 에러가 아니라 서버가 정상적으로 작동하여 보안 방어가 이루어지고 있다는 증거임.