### PR TITLE
feat: malang-deployer IAM 유저 및 GitHub Actions 배포 자동화

### DIFF
--- a/my_terraform/main.tf
+++ b/my_terraform/main.tf
@@ -65,3 +65,42 @@ resource "aws_iam_group_policy_attachment" "ops" {
   group      = aws_iam_group.malang_ops.name
   policy_arn = local.ops_policies[count.index]
 }
+
+# ===== 배포 전용 유저 =====
+resource "aws_iam_user" "malang_deployer" {
+  name = "malang-deployer"
+  tags = {
+    Project = var.project_name
+  }
+}
+
+# ===== 배포 전용 그룹 =====
+resource "aws_iam_group" "malang_deployer" {
+  name = "malang-deployer"
+}
+
+# ===== 그룹 멤버십 =====
+resource "aws_iam_user_group_membership" "malang_deployer" {
+  user = aws_iam_user.malang_deployer.name
+  groups = [
+    aws_iam_group.malang_deployer.name,
+  ]
+}
+
+# ===== 배포 전용 그룹 정책 =====
+locals {
+  deployer_policies = [
+    "arn:aws:iam::aws:policy/IAMFullAccess",
+    "arn:aws:iam::aws:policy/AWSCloudFormationFullAccess",
+    "arn:aws:iam::aws:policy/AWSLambda_FullAccess",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess",
+    "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+    "arn:aws:iam::aws:policy/AmazonAPIGatewayAdministrator",
+  ]
+}
+
+resource "aws_iam_group_policy_attachment" "deployer" {
+  count      = length(local.deployer_policies)
+  group      = aws_iam_group.malang_deployer.name
+  policy_arn = local.deployer_policies[count.index]
+}


### PR DESCRIPTION
## 변경 사항
- malang-deployer IAM 유저/그룹/정책 Terraform 코드화 (8pr)
- GitHub Actions SAM 자동 배포 워크플로우 추가 (deploy.yaml) (10pr)
- GitHub Actions Terraform 자동 적용 워크플로우 추가 (terraform.yaml) (now)

## 배포 전략
- malang-dev: 일반 개발용 (IAMReadOnly)
- malang-deployer: CI/CD 전용 (IAMFullAccess)