### PR TITLE
feat: terraform s3 bucket state  add

### DIFF
--- a/my_terraform/main.tf
+++ b/my_terraform/main.tf
@@ -5,6 +5,11 @@ terraform {
       version = "~> 5.0"
     }
   }
+  backend "s3" {
+    bucket = "aws-sam-cli-managed-default-samclisourcebucket-q9vup2aib9cv"
+    key    = "iam/terraform.tfstate"
+    region = "ap-northeast-2"
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
## 트러블슈팅: Terraform Remote Backend 설정

### 현상
GitHub Actions에서 terraform apply 실행 시 EntityAlreadyExists 에러 발생
malang-dev, malang-ops, malang-deployer 유저/그룹 전부 충돌

### 원인
로컬에서 import한 terraform.tfstate 파일이 GitHub에 올라가지 않아서
GitHub Actions가 빈 state에서 시작 → 기존 리소스를 새로 만들려다 충돌

### 해결
S3 Remote Backend 설정으로 state 파일을 중앙 관리
- backend "s3" 설정 추가 (기존 SAM 버킷 활용)
- terraform init -migrate-state 로 로컬 state → S3 마이그레이션
- 이후 GitHub Actions도 동일한 S3 state 참조