### PR TITLE
fix: 사망 상태 말랑이 쓰다듬기 KeyError 수정

### DIFF
--- a/database.py
+++ b/database.py
@@ -381,6 +381,10 @@ def stroking_malang(user_id, room_id):
     today = datetime.now().strftime("%Y-%m-%d")
     last_date = malang.get("last_stroking_malang", "")
     print(f"DEBUG DB DATA: {malang}")
+    # 사망 상태 체크
+    if malang.get("type") == "none" or int(malang.get("health", 0)) == 0:
+        return "💀 말랑이가 무지개 다리를 건넜어요...\n환생시켜주세요!", ""
+
     malang_type = malang.get("type", "typeA")
 
     new_level = int(malang["level"])
@@ -463,6 +467,10 @@ def clean_malang(user_id, room_id):
     # DB에서 날짜와 횟수 가져오기 (없으면 초기값)
     last_date = malang.get("last_clean_date", "")
     clean_count = int(malang.get("clean_count", 0))
+    # 사망 상태 체크
+    if malang.get("type") == "none" or int(malang.get("health", 0)) == 0:
+        return "💀 말랑이가 무지개 다리를 건넜어요...\n환생시켜주세요!", ""
+
     malang_type = malang.get("type", "typeA")
 
     # 날짜가 바뀌었으면 횟수 초기화


### PR DESCRIPTION
### 버그 수정
- 부하 테스트 중 발견된 `KeyError: 'none'` 수정
- 원인: 사망 상태(`health: 0`) 말랑이의 `type`이 `"none"`으로 저장된 유저에 대해 `stroking_malang` 함수에서 예외처리 누락
- 해결: 사망 상태 체크 로직 추가 (`type == "none"` or `health == 0` 시 안내 메시지 반환)

## 테스트 결과

| 지표 | 1차 (수정 전) | 2차 (수정 후) |
|------|-------------|-------------|
| 에러율 | 6.62% ❌ | 0% ✅ |
| p95 응답시간 | 63.84ms | 73.12ms |
| Lambda Errors | 0건 | 0건 |
| Lambda Throttles | 0건 | 0건 |